### PR TITLE
Update to mongoid 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ I like to develop application using Ruby on Rails. I find that most of my projec
 
 These versions works for sure but others may do.
 
-* Ruby 2.3.0
-* Rails 5.0.0
-* MongoDB
+* Ruby 2.4.0
+* Rails 5.0.2
+* MongoDB 6
 * Freemind 0.9
 
 ## Convention

--- a/lib/generators/mindapp/install_generator.rb
+++ b/lib/generators/mindapp/install_generator.rb
@@ -67,6 +67,19 @@ IMAGE_LOCATION = "upload"
 }
         end
 
+initializer "mongoid.rb" do
+%q{# encoding: utf-8
+#  
+# Mongoid 6 follows the new pattern of AR5 requiring a belongs_to relation to always require its parent
+# belongs_to` will now trigger a validation error by default if the association is not present.
+# You can turn this off on a per-association basis with `optional: true`.
+# (Note this new default only applies to new Rails apps that will be generated with
+# `config.active_record.belongs_to_required_by_default = true` in initializer.)  
+#
+Mongoid::Config.belongs_to_required_by_default = false
+}
+        end        
+
         inject_into_file 'config/environment.rb', :after => "initialize!"  do
           "\n\n# hack to fix cloudinary error https://github.com/archiloque/rest-client/issues/141" +
           "\nclass Hash\n  remove_method :read\nrescue\nend"

--- a/lib/generators/mindapp/templates/app/controllers/identities_controller.rb
+++ b/lib/generators/mindapp/templates/app/controllers/identities_controller.rb
@@ -1,5 +1,5 @@
 class IdentitiesController < ApplicationController
   def new
-    @identity = env['omniauth.identity']
+    @identity =request.env['omniauth.identity']
   end
 end

--- a/lib/generators/mindapp/templates/app/controllers/mindapp_controller.rb
+++ b/lib/generators/mindapp/templates/app/controllers/mindapp_controller.rb
@@ -31,7 +31,7 @@ class MindappController < ApplicationController
     else
       js = ""
     end
-    render plain: "<script>#{js}</script>"
+    render html: "<script>#{js}</script>"
   end
   def init
     module_code, code = params[:s].split(":")

--- a/lib/generators/mindapp/templates/app/controllers/mindapp_controller.rb
+++ b/lib/generators/mindapp/templates/app/controllers/mindapp_controller.rb
@@ -156,13 +156,13 @@ class MindappController < ApplicationController
         @doc= Mindapp::Doc.where(:runseq_id=>@runseq.id).first
         @doc.update_attributes :data_text=> render_to_string(:inline=>@ui, :layout=>"utf8"),
           :xmain=>@xmain, :runseq=>@runseq, :user=>current_user,
-          :ip=> get_ip, :service=>service, :display=>display,
+          :ip=> get_ip, :service=>service, :demonstrate=>display,
           :secured => @xmain.service.secured
       else
         @doc= Mindapp::Doc.create :name=> @runseq.name,
           :content_type=>"output", :data_text=> render_to_string(:inline=>@ui, :layout=>"utf8"),
           :xmain=>@xmain, :runseq=>@runseq, :user=>current_user,
-          :ip=> get_ip, :service=>service, :display=>display,
+          :ip=> get_ip, :service=>service, :demonstrate=>display,
           :secured => @xmain.service.secured
       end
       @message = defined?(MSG_NEXT) ? MSG_NEXT : "Next &gt;"
@@ -186,7 +186,7 @@ class MindappController < ApplicationController
     @doc= Mindapp::Doc.create :name=> @runseq.name,
       :content_type=>"mail", :data_text=> render_to_string(:inline=>@ui, :layout=>false),
       :xmain=>@xmain, :runseq=>@runseq, :user=>current_user,
-      :ip=> get_ip, :service=>service, :display=>false,
+      :ip=> get_ip, :service=>service, :demonstrate=>false,
       :secured => @xmain.service.secured
     eval "@xvars[:#{@runseq.code}] = url_for(:controller=>'mindapp', :action=>'document', :id=>@doc.id)"
     mail_from = get_option('from')
@@ -258,7 +258,7 @@ class MindappController < ApplicationController
         :filename=> params.original_filename,
         :content_type => params.content_type || 'application/zip',
         :data_text=> '',
-        :display=>true,
+        :demonstrate=>true,
         :secured => @xmain.service.secured )
     if defined?(IMAGE_LOCATION)
       filename = "#{IMAGE_LOCATION}/f#{Param.gen(:asset_id)}"
@@ -281,7 +281,7 @@ class MindappController < ApplicationController
       :filename=> params.original_filename,
       :content_type => params.content_type || 'application/zip',
       :data_text=> '',
-      :display=>true, :secured => @xmain.service.secured )
+      :demonstrate=>true, :secured => @xmain.service.secured )
     if defined?(IMAGE_LOCATION)
       filename = "#{IMAGE_LOCATION}/f#{Param.gen(:asset_id)}"
       File.open(filename,"wb") { |f| f.write(params.read) }
@@ -472,7 +472,7 @@ class MindappController < ApplicationController
         :filename=> (params[:file_name]||''),
         :content_type => (params[:content_type] || 'application/zip'),
         :data_text=> '',
-        :display=>true
+        :demonstrate=>true
       path = (IMAGE_LOCATION || "tmp")
       File.open("#{path}/f#{doc.id}","wb") { |f|
         f.puts(params[:content])

--- a/lib/generators/mindapp/templates/app/controllers/mindapp_controller.rb
+++ b/lib/generators/mindapp/templates/app/controllers/mindapp_controller.rb
@@ -25,13 +25,13 @@ class MindappController < ApplicationController
       redirect_to action:"pending"
   end
   def ajax_notice
-    if notice=Mindapp::Notice.recent(current_user, env["REMOTE_ADDR"])
+    if notice=Mindapp::Notice.recent(current_user,request.env["REMOTE_ADDR"])
       notice.update_attribute :unread, false
       js = "notice('#{notice.message}');"
     else
       js = ""
     end
-    render :text=> "<script>#{js}</script>"
+    render plain: "<script>#{js}</script>"
   end
   def init
     module_code, code = params[:s].split(":")
@@ -307,11 +307,11 @@ class MindappController < ApplicationController
     File.open('public/doc.html','w') {|f| f.puts html }
     respond_to do |format|
       format.html {
-        render :text=> @print+html, :layout => 'layouts/_page'
-        # render :text=> Maruku.new(doc).to_html, :layout => false
+        render plain: @print+html, :layout => 'layouts/_page'
+        # render plain: Maruku.new(doc).to_html, :layout => false
       # format.html {
       #   h = RDoc::Markup::ToHtml.new
-      #   render :text=> h.convert(doc), :layout => 'layouts/_page'
+      #   render plain: h.convert(doc), :layout => 'layouts/_page'
       }
       format.pdf  {
         latex= Maruku.new(doc).to_latex
@@ -320,7 +320,7 @@ class MindappController < ApplicationController
         # system('pdflatex tmp/doc.tex ')
         # send_file( 'tmp/doc.pdf', :type => ‘application/pdf’,
           # :disposition => ‘inline’, :filename => 'doc.pdf')
-        render :text=>'done'
+        render plain:'done'
       }
     end
   end

--- a/lib/generators/mindapp/templates/app/controllers/sessions_controller.rb
+++ b/lib/generators/mindapp/templates/app/controllers/sessions_controller.rb
@@ -18,7 +18,9 @@ class SessionsController < ApplicationController
   def destroy
     session[:user_id] = nil
     # redirect_to '/mindapp/help'
-    refresh_to root_path
+    #refresh_to root_path
+    #  render not work!!
+    redirect_to 'mindapp/index'
   end
 
   def failure

--- a/lib/generators/mindapp/templates/app/controllers/sessions_controller.rb
+++ b/lib/generators/mindapp/templates/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
   # then use attribute 'data-ajax'=>'false'
   # see app/views/sessions/new.html.erb for sample
   def create
-    user = User.from_omniauth(env["omniauth.auth"])
+    user = User.from_omniauth(request.env["omniauth.auth"])
     session[:user_id] = user.id
     redirect_to '/mindapp/pending'
   rescue

--- a/lib/generators/mindapp/templates/app/models/mindapp/doc.rb
+++ b/lib/generators/mindapp/templates/app/models/mindapp/doc.rb
@@ -14,7 +14,7 @@ class Mindapp::Doc
   belongs_to :user
   belongs_to :service, :class_name => "Mindapp::Service"
   field :ip, :type => String
-  field :display, :type => Boolean
+  field :demontrate, :type => Boolean
   field :secured, :type => Boolean
 
   def self.search(q, page, per_page=PER_PAGE)

--- a/lib/generators/mindapp/templates/app/models/user.rb
+++ b/lib/generators/mindapp/templates/app/models/user.rb
@@ -5,7 +5,7 @@ class User
   field :code, :type => String
   field :email, :type => String
   field :role, :type => String
-  belongs_to :identity
+  belongs_to :identity, :polymorphic => true, :optional => true
   has_many :xmains, :class_name => "Mindapp::Xmain"
 
   def has_role(role1)

--- a/lib/generators/mindapp/templates/spec/spec_helper.rb
+++ b/lib/generators/mindapp/templates/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] ||= 'test'
+REQUEST.ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'

--- a/lib/mindapp/helpers.rb
+++ b/lib/mindapp/helpers.rb
@@ -34,7 +34,7 @@ module Mindapp
       if option[:alert]
         ma_log option[:alert]
       end
-      render :text => "<script>window.location.replace('#{url}')</script>"
+      render plain: "<script>window.location.replace('#{url}')</script>"
     end
     def read_binary(path)
       File.open path, "rb" do |f| f.read end
@@ -115,10 +115,10 @@ module Mindapp
           :unread=> true, :ip=> ($ip || request.env["REMOTE_ADDR"])
       # if session[:user_id]
       #   Mindapp::Notice.create :message => ERB::Util.html_escape(message.gsub("`","'")),
-      #     :user_id => $user.id, :unread=> true, :ip=> env["REMOTE_ADDR"]
+      #     :user_id => $user.id, :unread=> true, :ip=>request.env["REMOTE_ADDR"]
       # else
       #   Mindapp::Notice.create :message => ERB::Util.html_escape(message.gsub("`","'")),
-      #     :unread=> true, :ip=> env["REMOTE_ADDR"]
+      #     :unread=> true, :ip=>request.env["REMOTE_ADDR"]
       # end
     end
 

--- a/lib/mindapp/helpers.rb
+++ b/lib/mindapp/helpers.rb
@@ -34,7 +34,7 @@ module Mindapp
       if option[:alert]
         ma_log option[:alert]
       end
-      render plain: "<script>window.location.replace('#{url}')</script>"
+      render html: "<script>window.location.replace('#{url}')</script>"
     end
     def read_binary(path)
       File.open path, "rb" do |f| f.read end

--- a/lib/tasks/mindapp.rake
+++ b/lib/tasks/mindapp.rake
@@ -120,7 +120,7 @@ end
     attr_hash.each do |a|
       # doc+= "\n*****"+a.to_s+"\n"
       if a[:edit]
-        doc += "  #{a[:text]}\n"
+        doc += "  #{a[plain:]}\n"
       else
         doc += "  field :#{a[:code]}, :type => #{a[:type].capitalize}\n"
       end

--- a/lib/tasks/mindapp.rake
+++ b/lib/tasks/mindapp.rake
@@ -120,7 +120,7 @@ end
     attr_hash.each do |a|
       # doc+= "\n*****"+a.to_s+"\n"
       if a[:edit]
-        doc += "  #{a[plain:]}\n"
+        doc += "  #{a[:text]}\n"
       else
         doc += "  field :#{a[:code]}, :type => #{a[:type].capitalize}\n"
       end


### PR DESCRIPTION
Original: when use with ruby 2.4.0@rails-5.0.2
1. When use mongoid 6 mindapp can not Sign In due to required option for belong_to
2. Sign Out error due to refresh_to called render not work then using around by redirect_to (Need to see why using refresh_to at first.)
Beaware:
Not yet test with mongoid earlier version
Not yet test with ruby/rails earlier version
Todo:
Test with previous version
Update required ruby and rails if need



